### PR TITLE
feat: add technical headline tag selection

### DIFF
--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -22,10 +22,39 @@ ExtensionManagementUtility::addTcaSelectItem(
 
 $GLOBALS['TCA']['tt_content']['ctrl']['typeicon_classes']['metypo3styleguide_technicalheadline'] = 'content-info';
 
+$GLOBALS['TCA']['tt_content']['columns'] = array_replace_recursive(
+    $GLOBALS['TCA']['tt_content']['columns'],
+    [
+        'tx_metypo3styleguide_technicalheadlinetag' => [
+            'label' => 'LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang.xlf:contentelement.technical_headline.tag',
+            'config' => [
+                'type' => 'select',
+                'renderType' => 'selectSingle',
+                'default' => 'h2',
+                'items' => [
+                    [
+                        'LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang.xlf:contentelement.technical_headline.tag.h2',
+                        'h2',
+                    ],
+                    [
+                        'LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang.xlf:contentelement.technical_headline.tag.h3',
+                        'h3',
+                    ],
+                    [
+                        'LLL:EXT:' . Configuration::EXT_KEY . '/Resources/Private/Language/locallang.xlf:contentelement.technical_headline.tag.h4',
+                        'h4',
+                    ],
+                ],
+            ],
+        ],
+    ]
+);
+
+
 $GLOBALS['TCA']['tt_content']['types']['metypo3styleguide_technicalheadline'] = [
     'showitem' => '--div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:general,
                     --palette--;;general,
-                    --palette--;;header,subheader,bodytext,
+                    --palette--;;header,tx_metypo3styleguide_technicalheadlinetag,subheader,bodytext,
                 --div--;LLL:EXT:frontend/Resources/Private/Language/locallang_ttc.xlf:tabs.appearance,
                     --palette--;;frames,
                 --div--;LLL:EXT:core/Resources/Private/Language/Form/locallang_tabs.xlf:language,

--- a/Resources/Private/Language/de.locallang.xlf
+++ b/Resources/Private/Language/de.locallang.xlf
@@ -15,6 +15,22 @@
 				<source />
 				<target>Hilfsinhalt um technische Informationen als Headline Element auszuspielen</target>
 			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag">
+				<source />
+				<target>Überschriften-Level</target>
+			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag.h2">
+				<source />
+				<target>h2</target>
+			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag.h3">
+				<source />
+				<target>h3</target>
+			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag.h4">
+				<source />
+				<target>h4</target>
+			</trans-unit>
 			<trans-unit id="technical_headline.headline.link.title">
 				<source />
 				<target>Link auf sich selbst</target>

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -12,6 +12,18 @@
 			<trans-unit id="contentelement.technical_headline.description">
 				<source>Helper content to display technical information as headline element</source>
 			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag">
+				<source>Headline-Level</source>
+			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag.h2">
+				<source>h2</source>
+			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag.h3">
+				<source>h3</source>
+			</trans-unit>
+			<trans-unit id="contentelement.technical_headline.tag.h4">
+				<source>h4</source>
+			</trans-unit>
 			<trans-unit id="technical_headline.headline.link.title">
 				<source>Link to itself</source>
 			</trans-unit>

--- a/Resources/Private/Templates/TechnicalHeadline.html
+++ b/Resources/Private/Templates/TechnicalHeadline.html
@@ -8,13 +8,13 @@
 <f:asset.script identifier="metypo3styleguide_technicalheadline_script" src="EXT:me_typo3_styleguide/Resources/Public/JavaScript/technical_headline.js" />
 
 <div class="technical-headline" id="{data.header -> sg:formatSlug()}">
-    <h2 class="technical-headline__headline">
+    <{data.tx_metypo3styleguide_technicalheadlinetag} class="technical-headline__headline">
         <a class="technical-headline__link" href="#{data.header -> sg:formatSlug()}">#<span class="visually-hidden">{f:translate(key: 'technical_headline.headline.link.title', extensionName: 'metypo3styleguide')}</span></a>
         <span class="technical-headline__title">{data.header}</span>
         <a class="technical-headline__to-top" href="#technical-headline-toc" aria-label="{f:translate(key: 'technical_headline.headline.top.title', extensionName: 'metypo3styleguide')}">
             &uarr;
         </a>
-    </h2>
+    </{data.tx_metypo3styleguide_technicalheadlinetag}>
     <f:if condition="{data.subheader}">
         <h3 class="technical-headline__label">{data.subheader}</h3>
     </f:if>

--- a/Resources/Public/Css/TechnicalHeadline.css
+++ b/Resources/Public/Css/TechnicalHeadline.css
@@ -12,6 +12,12 @@
     gap: 1rem;
     font-size: 1.75rem;
 }
+h3.technical-headline__headline {
+    font-size: 1.5rem;
+}
+h4.technical-headline__headline {
+    font-size: 1.25rem;
+}
 .technical-headline__link {
     color: #646464;
     text-decoration: none;
@@ -67,6 +73,12 @@
 }
 .technical-headline-toc__item {
     list-style: none;
+}
+.technical-headline-toc__item.h3 {
+    margin-left: 2rem;
+}
+.technical-headline-toc__item.h4 {
+    margin-left: 4rem;
 }
 .technical-headline-toc__item::before {
     content: '# ';

--- a/Resources/Public/JavaScript/technical_headline.js
+++ b/Resources/Public/JavaScript/technical_headline.js
@@ -41,9 +41,10 @@ class TechnicalHeadline {
     `
 
     this.technicalHeadlineEl.forEach(headlineEl => {
+      const tag = headlineEl.firstElementChild.tagName.toLowerCase()
       const title = headlineEl.querySelector(".technical-headline__title")
         ?.innerHTML
-      html += `<li class="technical-headline-toc__item"><a class="technical-headline-toc__link" href="#${headlineEl.getAttribute(
+      html += `<li class="technical-headline-toc__item ${tag}"><a class="technical-headline-toc__link" href="#${headlineEl.getAttribute(
         "id"
       )}">${title}</a></li>`
     })

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -1,0 +1,4 @@
+CREATE TABLE tt_content
+(
+	tx_metypo3styleguide_technicalheadlinetag varchar(30) COLLATE utf8_unicode_ci NOT NULL DEFAULT '0',
+);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a selectable headline level (h2, h3, h4) for technical headline content elements, allowing users to choose the desired HTML heading tag.
- **Enhancements**
  - Headline appearance and table of contents now visually reflect the selected heading level with updated font sizes and indentation.
- **Localization**
  - Introduced new translations for headline level options in both English and German interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->