### PR TITLE
feat: rename view helper classes and provide documentation

### DIFF
--- a/Classes/ViewHelpers/ContrastColorViewHelper.php
+++ b/Classes/ViewHelpers/ContrastColorViewHelper.php
@@ -5,6 +5,20 @@ namespace MoveElevator\Styleguide\ViewHelpers;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
+/**
+ * This ViewHelper generates a contrast color based on a given color.
+ *
+ * Usage:
+ * ```html
+ *
+ * <html
+ *   xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+ *   data-namespace-typo3-fluid="true"
+ * >
+ * <sg:contrastColor color="#ff5733" />
+ *
+ * ```
+ */
 class ContrastColorViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void

--- a/Classes/ViewHelpers/FilesViewHelper.php
+++ b/Classes/ViewHelpers/FilesViewHelper.php
@@ -6,6 +6,23 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
+/**
+ * This ViewHelper generates a list of files in a specified directory.
+ *
+ * Usage:
+ * ```html
+ *
+ * <html
+ *   xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+ *   data-namespace-typo3-fluid="true"
+ * >
+ *
+ * <f:for each="{sg:files(path: path)}" as="file">
+ *     {file}
+ * </f:for>
+ *
+ * ```
+ */
 class FilesViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void

--- a/Classes/ViewHelpers/Format/FilenameViewHelper.php
+++ b/Classes/ViewHelpers/Format/FilenameViewHelper.php
@@ -1,11 +1,30 @@
 <?php
 
-namespace MoveElevator\Styleguide\ViewHelpers;
+namespace MoveElevator\Styleguide\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
-class FormatFilenameViewHelper extends AbstractViewHelper
+/**
+ * This ViewHelper removes the file ending from a filename.
+ *
+ * Usages:
+ * ```html
+ * <html
+ *   xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+ *   data-namespace-typo3-fluid="true"
+ * >
+ * <sg:format.filename>logo.svg</xt3:format.filename>
+ *
+ * {value -> sg:format.filename()}
+ * ```
+ *
+ * Result:
+ * ```
+ * logo
+ * ```
+ */
+class FilenameViewHelper extends AbstractViewHelper
 {
     public function initializeArguments(): void
     {

--- a/Classes/ViewHelpers/Format/SlugViewHelper.php
+++ b/Classes/ViewHelpers/Format/SlugViewHelper.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace MoveElevator\Styleguide\ViewHelpers;
+namespace MoveElevator\Styleguide\ViewHelpers\Format;
 
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
@@ -11,12 +11,17 @@ use TYPO3Fluid\Fluid\Core\ViewHelper\Traits\CompileWithContentArgumentAndRenderS
  *
  * Usages:
  * ```html
- * <sg:formatSlug>XYZ</xt3:formatSlug>
+ * <html
+ *  xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+ *  data-namespace-typo3-fluid="true"
+ * >
  *
- * {value -> sg:formatSlug()}
+ * <sg:format.slug>XYZ</xt3:format.slug>
+ *
+ * {value -> sg:format.slug()}
  * ```
  */
-class FormatSlugViewHelper extends AbstractViewHelper
+class SlugViewHelper extends AbstractViewHelper
 {
     use CompileWithContentArgumentAndRenderStatic;
     public function initializeArguments(): void

--- a/Classes/ViewHelpers/Render/TemplateViewHelper.php
+++ b/Classes/ViewHelpers/Render/TemplateViewHelper.php
@@ -1,19 +1,27 @@
 <?php
-namespace MoveElevator\Styleguide\ViewHelpers;
+namespace MoveElevator\Styleguide\ViewHelpers\Render;
 
-/*
- * This file is part of the FluidTYPO3/Vhs project under GPLv2 or later.
- *
- * For the full copyright and license information, please read the
- * LICENSE.md file that was distributed with this source code.
- */
 
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Fluid\View\StandaloneView;
 use TYPO3Fluid\Fluid\Core\Rendering\RenderingContextInterface;
 use TYPO3Fluid\Fluid\Core\ViewHelper\AbstractViewHelper;
 
-class RenderTemplateViewHelper extends AbstractViewHelper
+/**
+ * This ViewHelper renders a template file with optional variables and paths.
+ *
+ * Usage:
+ * ```html
+ * <html
+ *   xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+ *   data-namespace-typo3-fluid="true"
+ * >
+ *
+ * <sg:render.template file="EXT:myext/Resources/Private/Templates/MyTemplate.html" variables="{myVar: 'value'}" />
+ * ```
+ *
+ */
+class TemplateViewHelper extends AbstractViewHelper
 {
     /**
      * @var bool
@@ -98,7 +106,7 @@ class RenderTemplateViewHelper extends AbstractViewHelper
     }
 
     /**
-     * @param \TYPO3\CMS\Extbase\Mvc\View\ViewInterface|ViewInterface $view
+     * @param \TYPO3\CMS\Extbase\Mvc\View\ViewInterface $view
      */
     protected static function renderView($view, array $arguments): string
     {

--- a/Documentation/ViewHelpers/CLASSES.md
+++ b/Documentation/ViewHelpers/CLASSES.md
@@ -1,0 +1,7 @@
+# Table of Contents
+
+- [ContrastColorViewHelper](./Classes/ContrastColorViewHelper.md)
+- [TemplateViewHelper](./Classes/TemplateViewHelper.md)
+- [FilesViewHelper](./Classes/FilesViewHelper.md)
+- [SlugViewHelper](./Classes/SlugViewHelper.md)
+- [FilenameViewHelper](./Classes/FilenameViewHelper.md)

--- a/Documentation/ViewHelpers/Classes/ContrastColorViewHelper.md
+++ b/Documentation/ViewHelpers/Classes/ContrastColorViewHelper.md
@@ -1,0 +1,15 @@
+# ContrastColorViewHelper
+
+This ViewHelper generates a contrast color based on a given color.
+
+Usage:
+```html
+
+<html
+  xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+  data-namespace-typo3-fluid="true"
+>
+<sg:contrastColor color="#ff5733" />
+
+```
+

--- a/Documentation/ViewHelpers/Classes/FilenameViewHelper.md
+++ b/Documentation/ViewHelpers/Classes/FilenameViewHelper.md
@@ -1,0 +1,20 @@
+# FilenameViewHelper
+
+This ViewHelper removes the file ending from a filename.
+
+Usages:
+```html
+<html
+  xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+  data-namespace-typo3-fluid="true"
+>
+<sg:formatFilename>logo.svg</xt3:formatFilename>
+
+{value -> sg:formatFilename()}
+```
+
+Result:
+```
+logo
+```
+

--- a/Documentation/ViewHelpers/Classes/FilenameViewHelper.md
+++ b/Documentation/ViewHelpers/Classes/FilenameViewHelper.md
@@ -8,9 +8,9 @@ Usages:
   xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
   data-namespace-typo3-fluid="true"
 >
-<sg:formatFilename>logo.svg</xt3:formatFilename>
+<sg:format.filename>logo.svg</xt3:format.filename>
 
-{value -> sg:formatFilename()}
+{value -> sg:format.filename()}
 ```
 
 Result:

--- a/Documentation/ViewHelpers/Classes/FilesViewHelper.md
+++ b/Documentation/ViewHelpers/Classes/FilesViewHelper.md
@@ -1,0 +1,18 @@
+# FilesViewHelper
+
+This ViewHelper generates a list of files in a specified directory.
+
+Usage:
+```html
+
+<html
+  xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+  data-namespace-typo3-fluid="true"
+>
+
+<f:for each="{sg:files(path: path)}" as="file">
+    {file}
+</f:for>
+
+```
+

--- a/Documentation/ViewHelpers/Classes/SlugViewHelper.md
+++ b/Documentation/ViewHelpers/Classes/SlugViewHelper.md
@@ -9,8 +9,8 @@ Usages:
  data-namespace-typo3-fluid="true"
 >
 
-<sg:formatSlug>XYZ</xt3:formatSlug>
+<sg:format.slug>XYZ</xt3:format.slug>
 
-{value -> sg:formatSlug()}
+{value -> sg:format.slug()}
 ```
 

--- a/Documentation/ViewHelpers/Classes/SlugViewHelper.md
+++ b/Documentation/ViewHelpers/Classes/SlugViewHelper.md
@@ -1,0 +1,16 @@
+# SlugViewHelper
+
+This ViewHelper formats a string to a readable url slug.
+
+Usages:
+```html
+<html
+ xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+ data-namespace-typo3-fluid="true"
+>
+
+<sg:formatSlug>XYZ</xt3:formatSlug>
+
+{value -> sg:formatSlug()}
+```
+

--- a/Documentation/ViewHelpers/Classes/TemplateViewHelper.md
+++ b/Documentation/ViewHelpers/Classes/TemplateViewHelper.md
@@ -1,0 +1,14 @@
+# TemplateViewHelper
+
+This ViewHelper renders a template file with optional variables and paths.
+
+Usage:
+```html
+<html
+  xmlns:sg="http://typo3.org/ns/MoveElevator/Styleguide/ViewHelpers"
+  data-namespace-typo3-fluid="true"
+>
+
+<sg:render.template file="EXT:myext/Resources/Private/Templates/MyTemplate.html" variables="{myVar: 'value'}" />
+```
+

--- a/Documentation/phpdoc.php
+++ b/Documentation/phpdoc.php
@@ -1,0 +1,158 @@
+<?php
+
+/**
+ * This script scans a specified directory (and its subdirectories) for PHP files,
+ * extracts class documentation comments, and generates corresponding Markdown files
+ * in a specified output directory. Additionally, it generates a table of contents
+ * Markdown file that lists all generated class documentation files.
+ *
+ * Usage: php script.php -d <input directory> -o <output directory> [-t <TOC_FILENAME>]
+ *
+ * - `-d <input directory>`: The directory to scan for PHP files.
+ * - `-o <output directory>`: The directory where the Markdown files will be saved.
+ * - `-t <TOC_FILENAME>`: (Optional) The name of the table of contents Markdown file. Defaults to 'CLASSES.md'.
+ */
+
+/**
+ * Reads a file and returns its content as a string.
+ *
+ * @param string $file Path to the file
+ * @return string Content of the file
+ */
+function readFileContent($file)
+{
+    return file_get_contents($file);
+}
+
+/**
+ * Extracts class documentation comments from the file content.
+ *
+ * @param string $content Content of the PHP file
+ * @return array Extracted documentation comments
+ */
+function extractDocComments($content)
+{
+    $docComments = [
+        'classes' => [],
+    ];
+
+    // Regex for class documentation
+    preg_match_all('/\/\*\*(.*?)\*\/\s*class\s+(\w+)/s', $content, $classMatches, PREG_SET_ORDER);
+    foreach ($classMatches as $match) {
+        $docComments['classes'][] = [
+            'name' => $match[2],
+            'comment' => cleanDocComment($match[1]),
+        ];
+    }
+
+    return $docComments;
+}
+
+/**
+ * Cleans the doc comments by removing the comment asterisks and preserving line breaks.
+ *
+ * @param string $comment The comment to clean
+ * @return string The cleaned comment
+ */
+function cleanDocComment($comment)
+{
+    $comment = preg_replace('/^[ \t]*\*[ \t]?/m', '', $comment);
+    return trim($comment);
+}
+
+/**
+ * Generates a markdown file from the extracted documentation comments.
+ *
+ * @param string $className Name of the class
+ * @param array $docComments Extracted documentation comments
+ * @param string $outputDir Path to the output directory
+ * @return string Name of the generated markdown file
+ */
+function generateMarkdown($className, $docComments, $outputDir)
+{
+    $markdown = "# $className\n\n";
+
+    foreach ($docComments['classes'] as $class) {
+        $markdown .= "{$class['comment']}\n\n";
+    }
+
+    $fileName = "$outputDir/Classes/$className.md";
+    if (!is_dir(dirname($fileName))) {
+        die("The specified output directory 'Classes' does not exist.\n");
+    }
+    file_put_contents($fileName, $markdown);
+
+    return $fileName;
+}
+
+/**
+ * Recursively processes a directory for PHP files and generates markdown files for each found class.
+ * Also creates a main markdown file with a table of contents.
+ *
+ * @param string $directory Path to the directory
+ * @param string $outputDir Path to the output directory
+ * @param string $tocFileName Name of the table of contents file
+ */
+function processDirectory($directory, $outputDir, $tocFileName)
+{
+    $iterator = new RecursiveIteratorIterator(new RecursiveDirectoryIterator($directory));
+    $generatedFiles = [];
+
+    foreach ($iterator as $file) {
+        if (pathinfo($file, PATHINFO_EXTENSION) === 'php') {
+            $content = readFileContent($file);
+            $docComments = extractDocComments($content);
+
+            if (!empty($docComments['classes'])) {
+                $className = basename($file, '.php');
+                $generatedFile = generateMarkdown($className, $docComments, $outputDir);
+                $generatedFiles[] = $generatedFile;
+            }
+        }
+    }
+
+    generateTableOfContents($generatedFiles, $outputDir, $tocFileName);
+}
+
+/**
+ * Generates a main markdown file with a table of contents of all generated markdown files.
+ *
+ * @param array $generatedFiles List of generated markdown files
+ * @param string $outputDir Path to the output directory
+ * @param string $tocFileName Name of the table of contents file
+ */
+function generateTableOfContents($generatedFiles, $outputDir, $tocFileName)
+{
+    $toc = "# Table of Contents\n\n";
+    foreach ($generatedFiles as $file) {
+        $className = basename($file, '.md');
+        $toc .= "- [$className](./Classes/$className.md)\n";
+    }
+
+    file_put_contents("$outputDir/$tocFileName", $toc);
+}
+
+// Parse command line arguments
+$options = getopt('d:o:t::');
+if (!isset($options['d'])) {
+    die("Usage: php script.php -d <directory> -o <output directory> [-t <TOC_FILENAME>]\n");
+}
+
+$directory = $options['d'];
+$outputDir = isset($options['o']) ? $options['o'] : '.';
+$tocFileName = isset($options['t']) ? $options['t'] : 'CLASSES.md';
+
+if (!is_dir($directory)) {
+    die("The specified directory does not exist.\n");
+}
+
+if (!is_dir($outputDir) || !is_writable($outputDir)) {
+    die("The specified output directory does not exist or is not writable.\n");
+}
+
+if (!is_dir("$outputDir/Classes") || !is_writable("$outputDir/Classes")) {
+    die("The specified output directory 'Classes' does not exist or is not writable.\n");
+}
+
+// Process the directory
+processDirectory($directory, $outputDir, $tocFileName);

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ __Features__:
 composer require move-elevator/me-typo3-styleguide
 ```
 
+## Documentation
+
+### ViewHelpers
+
+See the [ViewHelpers documentation](./Documentation/ViewHelpers/CLASSES.md) for a complete list of available ViewHelpers.
+
 ## License
 
 This project is licensed

--- a/Resources/Private/Templates/Support/Icons.html
+++ b/Resources/Private/Templates/Support/Icons.html
@@ -18,7 +18,7 @@
                 </div>
                 <div class="me-typo3-styleguide__element-caption">
                     <p class="me-typo3-styleguide__image-caption-text">
-                        {file -> sg:formatFilename()}
+                        {file -> sg:format.filename()}
                     </p>
                 </div>
             </div>

--- a/Resources/Private/Templates/TechnicalHeadline.html
+++ b/Resources/Private/Templates/TechnicalHeadline.html
@@ -9,7 +9,7 @@
 
 <div class="technical-headline" id="{data.header -> sg:formatSlug()}">
     <{data.tx_metypo3styleguide_technicalheadlinetag} class="technical-headline__headline">
-        <a class="technical-headline__link" href="#{data.header -> sg:formatSlug()}">#<span class="visually-hidden">{f:translate(key: 'technical_headline.headline.link.title', extensionName: 'metypo3styleguide')}</span></a>
+        <a class="technical-headline__link" href="#{data.header -> sg:format.slug()}">#<span class="visually-hidden">{f:translate(key: 'technical_headline.headline.link.title', extensionName: 'metypo3styleguide')}</span></a>
         <span class="technical-headline__title">{data.header}</span>
         <a class="technical-headline__to-top" href="#technical-headline-toc" aria-label="{f:translate(key: 'technical_headline.headline.top.title', extensionName: 'metypo3styleguide')}">
             &uarr;

--- a/composer.json
+++ b/composer.json
@@ -48,6 +48,7 @@
 		}
 	},
 	"scripts": {
+		"doc:viewhelpers": "php Documentation/phpdoc.php -d Classes/ViewHelpers -o Documentation/ViewHelpers",
 		"php:lint": "find *.php . -name '*.php' ! -path './vendor/*'  ! -path './var/*' ! -path '*node_modules/*' -print0 | xargs -0 -n 1 -P 4 php -l",
 		"php:fixer": "php vendor/bin/php-cs-fixer --config=php-cs-fixer.php fix",
 		"php:stan": "php vendor/bin/phpstan --generate-baseline=phpstan-baseline.neon --allow-empty-baseline --memory-limit=2G",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added comprehensive documentation for all ViewHelpers, including individual markdown files and a table of contents.
  - Introduced a PHP script to auto-generate ViewHelper documentation from code comments.
  - Updated README with a reference to the new ViewHelpers documentation.

- **Refactor**
  - Renamed and reorganized several ViewHelper classes and namespaces for improved clarity and consistency.
  - Updated template usage to reflect new ViewHelper naming conventions.

- **Chores**
  - Added a Composer script to automate ViewHelper documentation generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->