### PR TITLE
fix: update CSS asset references to use Patterns.css instead of Elements.css

### DIFF
--- a/Resources/Private/Templates/Patterns/Colors.html
+++ b/Resources/Private/Templates/Patterns/Colors.html
@@ -5,7 +5,7 @@
 >
 
 <f:asset.css identifier="metypo3styleguide_element_css"
-             href="EXT:me_typo3_styleguide/Resources/Public/Css/Elements.css"/>
+             href="EXT:me_typo3_styleguide/Resources/Public/Css/Patterns.css"/>
 
 <div class="me-typo3-styleguide__frame">
     <div class="me-typo3-styleguide__element-container">

--- a/Resources/Private/Templates/Patterns/Fonts.html
+++ b/Resources/Private/Templates/Patterns/Fonts.html
@@ -5,7 +5,7 @@
 >
 
 <f:asset.css identifier="metypo3styleguide_element_css"
-             href="EXT:me_typo3_styleguide/Resources/Public/Css/Elements.css"/>
+             href="EXT:me_typo3_styleguide/Resources/Public/Css/Patterns.css"/>
 
 <div class="me-typo3-styleguide__frame">
     <div class="me-typo3-styleguide__element-container">

--- a/Resources/Private/Templates/Patterns/Icons.html
+++ b/Resources/Private/Templates/Patterns/Icons.html
@@ -5,7 +5,7 @@
 >
 
 <f:asset.css identifier="metypo3styleguide_element_css"
-             href="EXT:me_typo3_styleguide/Resources/Public/Css/Elements.css"/>
+             href="EXT:me_typo3_styleguide/Resources/Public/Css/Patterns.css"/>
 
 <div class="me-typo3-styleguide__frame">
     <div class="me-typo3-styleguide__element-container">

--- a/Resources/Private/Templates/Patterns/Images.html
+++ b/Resources/Private/Templates/Patterns/Images.html
@@ -5,7 +5,7 @@
 >
 
 <f:asset.css identifier="metypo3styleguide_element_css"
-             href="EXT:me_typo3_styleguide/Resources/Public/Css/Elements.css"/>
+             href="EXT:me_typo3_styleguide/Resources/Public/Css/Patterns.css"/>
 
 
 <div class="me-typo3-styleguide__frame">

--- a/Resources/Private/Templates/Patterns/Templates.html
+++ b/Resources/Private/Templates/Patterns/Templates.html
@@ -5,7 +5,7 @@
 >
 
 <f:asset.css identifier="metypo3styleguide_element_css"
-             href="EXT:me_typo3_styleguide/Resources/Public/Css/Elements.css"/>
+             href="EXT:me_typo3_styleguide/Resources/Public/Css/Patterns.css"/>
 
 <div class="me-typo3-styleguide__frame">
     <div class="me-typo3-styleguide__element-container">


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
	- Updated the stylesheet applied to Colors, Fonts, Icons, Images, and Templates pattern pages, switching from "Elements.css" to "Patterns.css" for improved and unified visual styling across these templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->